### PR TITLE
Increase line-height on the blockquote paragraphs

### DIFF
--- a/style.css
+++ b/style.css
@@ -933,7 +933,7 @@ div.show-image {
 
 .entry-content blockquote p {
 	font-style: italic;
-	line-height: 1.3;
+	line-height: 1.7;
 	padding: 0;
 }
 


### PR DESCRIPTION
We're using a relatively airy line-height of 1.7 in the rest of the copy, but inside the blockquote paragraph element it's 1.3.

This makes the lines feel a bit tight when reading, so upping it to 1.7 makes it consistent with the rest of the text, and from my perspective at least, a bit more comfortable to read.

**Line-height of 1.3**
![Screenshot 2020-10-23 at 21 32 14](https://user-images.githubusercontent.com/17906/97046718-15be8b80-1578-11eb-850b-660e5cc6782b.png)


**Line-height of 1.7**

![Screenshot 2020-10-23 at 21 31 44](https://user-images.githubusercontent.com/17906/97046727-19eaa900-1578-11eb-9fce-1642722a7fe3.png)

**Tom's mockups on Miro**
I think this is largely [in-line with Tom's inital mockups using quotes on miro](https://miro.com/app/board/o9J_kpbKXb8=/?moveToWidget=3074457349448630318&cot=14), but this suuuper low priority in any case. I'll tag him for input next week,

![Screenshot 2020-10-23 at 21 39 43](https://user-images.githubusercontent.com/17906/97046908-67ffac80-1578-11eb-854e-51874472a6b9.png)


👍🏽 ?